### PR TITLE
Fix broken syntax for Neo4j 5.x

### DIFF
--- a/course_material/03_01.txt
+++ b/course_material/03_01.txt
@@ -2,11 +2,11 @@
 MATCH (n) DETACH DELETE n;
 
 //Add constraints
-CREATE CONSTRAINT IF NOT EXISTS ON (student:Student) ASSERT student.id IS UNIQUE;
-CREATE CONSTRAINT IF NOT EXISTS ON (state:State) ASSERT state.name IS UNIQUE;
-CREATE CONSTRAINT IF NOT EXISTS ON (gradYear:Year) ASSERT gradYear.value IS UNIQUE;
-CREATE CONSTRAINT IF NOT EXISTS ON (program:Program) ASSERT program.name IS UNIQUE;
-CREATE CONSTRAINT IF NOT EXISTS ON (country:Country) ASSERT country.name IS UNIQUE;
+CREATE CONSTRAINT IF NOT EXISTS FOR (student:Student) REQUIRE student.id IS UNIQUE;
+CREATE CONSTRAINT IF NOT EXISTS FOR (state:State) REQUIRE state.name IS UNIQUE;
+CREATE CONSTRAINT IF NOT EXISTS FOR (gradYear:Year) REQUIRE gradYear.value IS UNIQUE;
+CREATE CONSTRAINT IF NOT EXISTS FOR (program:Program) REQUIRE program.name IS UNIQUE;
+CREATE CONSTRAINT IF NOT EXISTS FOR (country:Country) REQUIRE country.name IS UNIQUE;
 
 //Load data. We will use several statements to minimise eager queries and flat file downloads. 
 //Note that this may not be how you'd typically do this!


### PR DESCRIPTION
Changes are limited to fix for Issue #1

Fix broken syntax for Neo4j 5.x
- Changes limited to course_material/03_01.txt only
- Replace ON with FOR
- Replace ASSERT with REQUIRE



<!-- This repository *does not* accept pull requests (PRs). All pull requests will be closed. See CONTRIBUTING.md for further details. -->
